### PR TITLE
Remove test paragraph from jobs component template

### DIFF
--- a/src/app/feature/jobs/jobs.component.html
+++ b/src/app/feature/jobs/jobs.component.html
@@ -1,5 +1,4 @@
 <h1 cds-text="display">Current Job Openings</h1>
-<p>TESTING</p>
 <div cds-layout="grid cols@md:4 gap:md">
   @for (job of jobs(); track job.id) {
     <app-job-card [job]="job" />


### PR DESCRIPTION
The placeholder paragraph "TESTING" was removed from the jobs.component.html file. This cleanup ensures the HTML contents are production-ready and visually clean. The change does not affect the overall functionality of the component.