### PR TITLE
Add applicant name to Word doc metadata and filename

### DIFF
--- a/src/app/core/util/get-formatted-timestamp.ts
+++ b/src/app/core/util/get-formatted-timestamp.ts
@@ -1,11 +1,18 @@
+/**
+ * Generates a formatted timestamp string in the format 'YYMMDD_HHMMSS',
+ * where 'YY' is the last two digits of the year, 'MM' is the month,
+ * 'DD' is the day, 'HH' is the hour, 'MM' is the minutes, and 'SS' is the seconds.
+ *
+ * @return {string} A string representing the current date and time formatted as 'YYMMDD_HHMMSS'.
+ */
 export function getFormattedTimestamp(): string {
   const now = new Date();
-  const year = now.getFullYear();
+  const year = String(now.getFullYear()).slice(-2);
   const month = String(now.getMonth() + 1).padStart(2, '0');
   const day = String(now.getDate()).padStart(2, '0');
   const hours = String(now.getHours()).padStart(2, '0');
   const minutes = String(now.getMinutes()).padStart(2, '0');
   const seconds = String(now.getSeconds()).padStart(2, '0');
 
-  return `${year}-${month}-${day}_${hours}-${minutes}-${seconds}`;
+  return `${year}${month}${day}_${hours}${minutes}${seconds}`;
 }


### PR DESCRIPTION
Introduce a private method to extract the applicant's name from the form and include it in the document metadata. Additionally, update the filename format to incorporate the job title and applicant name, enhancing file organization and searchability. Adjust timestamp generation for a more concise format.